### PR TITLE
Loosen activesupport requirement

### DIFF
--- a/split_rails_logs.gemspec
+++ b/split_rails_logs.gemspec
@@ -10,6 +10,6 @@ spec = Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0'
 
-  s.add_dependency 'activesupport', '~> 5.0'
+  s.add_dependency 'activesupport', '>= 5.0'
   s.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
The activesupport 5 requirement blocks dependent applications from upgrading to Rails 6, so this loosens it to anything after 5.