### PR TITLE
Loosen Ruby version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ branches:
     - master
 language: ruby
 rvm:
-  - 2.4.1
+  - 2.7
+  - 3.0
+  - 3.1
 script: bundle exec rspec

--- a/split_rails_logs.gemspec
+++ b/split_rails_logs.gemspec
@@ -8,7 +8,7 @@ spec = Gem::Specification.new do |s|
 
   s.files = `git ls-files -- lib/*`.split("\n")
 
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_dependency 'activesupport', '>= 5.0'
   s.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
This constraint prevents using this gem with Ruby 3+.

This tightens it to 2.7, which in a week will be the oldest still supported version, and adds 2.7, 3.0, and 3.1 releases to the travis config for testing.
