### PR TITLE
Use ActiveSupport::Logger

### DIFF
--- a/lib/split_rails_logs.rb
+++ b/lib/split_rails_logs.rb
@@ -1,6 +1,5 @@
 require "active_support"
 require "fileutils"
-require "logger"
 require "stringio"
 
 class SplitRailsLogs
@@ -24,7 +23,7 @@ class SplitRailsLogs
     # reusing the io and logger instances each time prevents
     # runaway memory usage
     @io ||= StringIO.new
-    @logger ||= Logger.new(@io).tap do |logger|
+    @logger ||= ActiveSupport::Logger.new(@io).tap do |logger|
       Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
     end
 


### PR DESCRIPTION
Changes introduced in https://github.com/rails/rails/pull/44695 unfortunately mean using a plain `Logger` here does not work with broadcasting.
