### PR TITLE
Require ActiveSupport 7

### DIFF
--- a/lib/split_rails_logs.rb
+++ b/lib/split_rails_logs.rb
@@ -24,7 +24,7 @@ class SplitRailsLogs
     # runaway memory usage
     @io ||= StringIO.new
     @logger ||= ActiveSupport::Logger.new(@io).tap do |logger|
-      Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
+      Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, logger)
     end
 
     # beause we're reusing the same io and logger

--- a/spec/split_rails_logs_spec.rb
+++ b/spec/split_rails_logs_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SplitRailsLogs do
     stub_const("Rails", double(
       root: Pathname.new("foo"),
       logger: Logger.new(nil),
+      "logger=": nil,
       initialized?: true,
     ))
   end

--- a/split_rails_logs.gemspec
+++ b/split_rails_logs.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'split_rails_logs'
-  s.version = '1.1.0'
+  s.version = '2.0.0'
   s.licenses = ['MIT']
   s.summary = 'Split Rails logs across RSpec examples'
   s.authors = ["Nick Browne"]
@@ -10,6 +10,6 @@ spec = Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency 'activesupport', '>= 5.0'
+  s.add_dependency 'activesupport', '>= 7.1', '< 8'
   s.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
The broadcast logger API changed in ActiveSupport 7.1, replacing`Logger#broadcast` with `BroadcastLogger`. In order for TC to upgrade to Rails 7.1, we need to update this gem to use the new API.

Since this is a breaking change, we'll bump the version to 2.0.0.

See https://github.com/rails/rails/commit/1fbd812c47f7ba840390942e56d9b2ebbc260901
